### PR TITLE
Fix StateMachine#state_for_event not coercing :state to a symbol.

### DIFF
--- a/lib/end_state/state_machine.rb
+++ b/lib/end_state/state_machine.rb
@@ -97,7 +97,7 @@ module EndState
     def state_for_event(event)
       transitions = self.class.events[event]
       return false unless transitions
-      return invalid_event(event) unless transitions.map { |t| t.keys.first }.include?(state)
+      return invalid_event(event) unless transitions.map { |t| t.keys.first }.include?(state.to_sym)
       transitions.first.values.first
     end
 


### PR DESCRIPTION
Without the .to_sym coercion  on :state, all events return as invalid. This commit contains the fix.
