### PR TITLE
Add StateMachine#current_state? predicate method.

### DIFF
--- a/lib/end_state/state_machine.rb
+++ b/lib/end_state/state_machine.rb
@@ -80,12 +80,11 @@ module EndState
 
     def method_missing(method, *args, &block)
       check_state = method.to_s[0..-2].to_sym
+      return current_state?(check_state) if method.to_s.end_with?('?')
       check_state = state_for_event(check_state) || check_state
       return false if check_state == :__invalid_event__
       return super unless self.class.states.include?(check_state)
-      if method.to_s.end_with?('?')
-        state.to_sym == check_state
-      elsif method.to_s.end_with?('!')
+      if method.to_s.end_with?('!')
         transition check_state, args[0]
       else
         super
@@ -93,6 +92,10 @@ module EndState
     end
 
     private
+
+    def current_state?(check_state)
+      state.to_sym == check_state
+    end
 
     def state_for_event(event)
       transitions = self.class.events[event]

--- a/spec/end_state/state_machine_spec.rb
+++ b/spec/end_state/state_machine_spec.rb
@@ -130,6 +130,16 @@ module EndState
         specify { expect(machine.b?).to be_true }
         specify { expect(machine.a?).to be_false }
       end
+
+      context 'when the state shares a name with an event' do
+        before { StateMachine.transition start: :stop, as: :stop }
+
+        context 'and the object, in that state, cannot transition on the event' do
+          let(:object) { OpenStruct.new(state: :stop) }
+
+          specify { expect(machine.stop?).to be_true }
+        end
+      end
     end
 
     describe '#{state}!' do
@@ -261,7 +271,7 @@ module EndState
             it 'sends the guard the params' do
               machine.transition :b, params, :soft
               expect(guard).to have_received(:new).with(machine, :b, params)
-            end  
+            end
           end
         end
 


### PR DESCRIPTION
Need to return early from StateMachine#method_missing if we're performing a
state predicate check. Originally, the check happened after performing the
event lookup, but this would prevent predicate checks, if the state matched
an event and that even couldn't transition.

This commit fixes this problem and includes a regression unit spec.
