### PR TITLE
Add initial state feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ machine.state               # => :b
 
 ## Initial State
 
-If you wrap an object that currently has `nil` as the state, the state will be set to `:nil_state`.
+If you wrap an object that currently has `nil` as the state, the state will be set to `:__nil__`.
 You can change this using the `set_initial_state` method.
 
 ```ruby

--- a/lib/end_state/state_machine.rb
+++ b/lib/end_state/state_machine.rb
@@ -7,7 +7,7 @@ module EndState
       Action.new(self, self.class.initial_state).call if self.state.nil?
     end
 
-    @initial_state = :nil_state
+    @initial_state = :__nil__
 
     def self.initial_state
       @initial_state

--- a/spec/end_state/state_machine_spec.rb
+++ b/spec/end_state/state_machine_spec.rb
@@ -9,7 +9,7 @@ module EndState
       StateMachine.instance_variable_set '@transitions'.to_sym, nil
       StateMachine.instance_variable_set '@events'.to_sym, nil
       StateMachine.instance_variable_set '@store_states_as_strings'.to_sym, nil
-      StateMachine.instance_variable_set '@initial_state'.to_sym, :nil_state
+      StateMachine.instance_variable_set '@initial_state'.to_sym, :__nil__
     end
 
     describe '.transition' do
@@ -110,7 +110,7 @@ module EndState
 
     describe '#state' do
       context 'when there is no state set' do
-        specify { expect(machine.state).to eq :nil_state }
+        specify { expect(machine.state).to eq :__nil__ }
       end
 
       context 'when the object has state :a' do


### PR DESCRIPTION
Add the ability to set the initial state of the machine. Adding this also allows an easy way to handle what happens when they wrap an object with a `nil` state.
