### PR TITLE
Add early 'return super' to method_missing.

### DIFF
--- a/lib/end_state/state_machine.rb
+++ b/lib/end_state/state_machine.rb
@@ -95,10 +95,10 @@ module EndState
 
     def method_missing(method, *args, &block)
       check_state = method.to_s[0..-2].to_sym
+      return super unless is_state_or_event?(check_state)
       return current_state?(check_state) if method.to_s.end_with?('?')
       check_state = state_for_event(check_state) || check_state
       return false if check_state == :__invalid_event__
-      return super unless self.class.states.include?(check_state)
       if method.to_s.end_with?('!')
         transition check_state, args[0]
       else
@@ -107,6 +107,10 @@ module EndState
     end
 
     private
+
+    def is_state_or_event?(check_state)
+      self.class.states.include?(check_state) or self.class.events[check_state]
+    end
 
     def current_state?(check_state)
       state.to_sym == check_state

--- a/spec/end_state/state_machine_spec.rb
+++ b/spec/end_state/state_machine_spec.rb
@@ -155,6 +155,18 @@ module EndState
           specify { expect(machine.stop?).to be_true }
         end
       end
+
+      context 'when the requested predicate is not a state or event' do
+        module Predicate
+          def foo? ; :foo ; end
+        end
+
+        before { object.extend(Predicate) }
+
+        it 'call super up to SimpleDelegator, which handles the method' do
+          expect(machine.foo?).to eq(:foo)
+        end
+      end
     end
 
     describe '#{state}!' do


### PR DESCRIPTION
We only want to process {state} and {event} method calls that end with
either '?' or '!'. If we don't see that, we immediately super out, so
the wrapped object can handle the method.
Includes a unit spec to verify the correct behavior.
