### PR TITLE
Remove blocked

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,17 +243,12 @@ end
 ## Events
 
 By using the `as` option in a transition definition you are creating an event representing that transition.
-This can allow you to exercise the machine in a more natural "verb" style interaction. When using `as` event
-definitions you can optionally set a `blocked` message on the transition. When the event is executed, if the
-machine is not in the initial state of the event, the message is added to the `failure_messages`
-array on the machine. Events, like `transition` have both a standard and a bang (`!`) style. The bang style
-will raise an exception if there is a problem.
+This can allow you to exercise the machine in a more natural "verb" style interaction. Events, like `transition`
+have both a standard and a bang (`!`) style. The bang style will raise an exception if there is a problem.
 
 ```ruby
 class Machine < EndState::StateMachine
-  transition a: :b, as: :go do |t|
-    t.blocked 'Cannot go!'
-  end
+  transition a: :b, as: :go
 end
 
 machine = Machine.new(StatefulObject.new(:a))
@@ -261,7 +256,6 @@ machine = Machine.new(StatefulObject.new(:a))
 machine.go                  # => true
 machine.state               # => :b
 machine.go                  # => false
-machine.failure_messages    # => ['Cannot go!']
 machine.go!                 # => raises InvalidTransition
 ```
 

--- a/lib/end_state/state_machine.rb
+++ b/lib/end_state/state_machine.rb
@@ -78,8 +78,6 @@ module EndState
 
     def __sm_invalid_event(event, mode)
       fail InvalidTransition, "Transition by event: #{event} is invalid." if mode == :hard
-      message = self.class.transition_configurations[self.class.events[event].first].blocked_event_message
-      @failure_messages = [message] if message
       :__invalid_event__
     end
 

--- a/lib/end_state/transition_configuration.rb
+++ b/lib/end_state/transition_configuration.rb
@@ -1,11 +1,10 @@
 module EndState
   class TransitionConfiguration
-    attr_reader :action, :allowed_params, :blocked_event_message, :concluders, :guards, :required_params
+    attr_reader :action, :allowed_params, :concluders, :guards, :required_params
 
     def initialize
       @action = Action
       @allowed_params = []
-      @blocked_event_message = nil
       @concluders = []
       @guards = []
       @required_params = []
@@ -38,10 +37,6 @@ module EndState
         append_unless_included(:allowed_params, param)
         append_unless_included(:required_params, param)
       end
-    end
-
-    def blocked(message)
-      @blocked_event_message = message
     end
 
     private

--- a/spec/end_state/state_machine_spec.rb
+++ b/spec/end_state/state_machine_spec.rb
@@ -79,9 +79,7 @@ module EndState
 
       context 'single transition' do
         before do
-          StateMachine.transition a: :b, as: :go do |t|
-            t.blocked 'Invalid event!'
-          end
+          StateMachine.transition a: :b, as: :go
         end
 
         it 'transitions the state' do
@@ -109,11 +107,6 @@ module EndState
             expect(machine.state).to eq :c
           end
 
-          it 'adds a failure message specified by blocked' do
-            machine.go
-            expect(machine.failure_messages).to eq ['Invalid event!']
-          end
-
           context 'and all transitions are forced to run in :hard mode' do
             before { machine.class.treat_all_transitions_as_hard! }
 
@@ -137,9 +130,7 @@ module EndState
 
       context 'multiple start states' do
         before do
-          StateMachine.transition [:a, :b] => :c, as: :go do |t|
-            t.blocked 'Invalid event!'
-          end
+          StateMachine.transition [:a, :b] => :c, as: :go
         end
 
         context 'initial state is :a' do
@@ -172,9 +163,7 @@ module EndState
 
       context 'multiple transitions' do
         before do
-          StateMachine.transition a: :b, c: :d, as: :go do |t|
-            t.blocked 'Invalid event!'
-          end
+          StateMachine.transition a: :b, c: :d, as: :go
         end
 
         context 'initial state is :a' do
@@ -200,9 +189,7 @@ module EndState
     describe '#{event}!' do
       let(:object) { OpenStruct.new(state: :a) }
       before do
-        StateMachine.transition a: :b, as: :go do |t|
-          t.blocked 'Invalid event!'
-        end
+        StateMachine.transition a: :b, as: :go
       end
 
       it 'transitions the state' do

--- a/spec/end_state/transition_configuration_spec.rb
+++ b/spec/end_state/transition_configuration_spec.rb
@@ -14,13 +14,6 @@ module EndState
       end
     end
 
-    describe '#blocked' do
-      it 'sets the blocked event message' do
-        config.blocked 'This is blocked.'
-        expect(config.blocked_event_message).to eq 'This is blocked.'
-      end
-    end
-
     describe '#guard' do
       let(:guard) { double :guard }
       let(:another_guard) { double :another_guard }


### PR DESCRIPTION
Events aren't guaranteed to pertain to only a single
TransitionConfiguration
